### PR TITLE
Use Join-Path for $pfk

### DIFF
--- a/Install-TheFucker.ps1
+++ b/Install-TheFucker.ps1
@@ -1,5 +1,5 @@
 $dst = (Join-Path $env:PSModulePath.Split(';')[0] PoShFuck);
-$pfk = "$env:temp\poshfuck.zip"
+$pfk = (Join-Path $env:temp "poshfuck.zip")
 
 md $dst -ea silentlycontinue
 


### PR DESCRIPTION
To prevent ambiguity in trailing slash in $env:temp, use the Join-Path cmdlet for $pfk as well.