### PR TITLE
fixing installer issue when `PSModulePath` is screwed up 

### DIFF
--- a/Install-TheFucker.ps1
+++ b/Install-TheFucker.ps1
@@ -1,4 +1,4 @@
-$dst = (Join-Path $env:PSModulePath.Split(';')[0] PoShFuck);
+$dst = "$env:ProgramFiles\WindowsPowerShell\Modules\PoShFuck"
 $pfk = (Join-Path $env:temp "poshfuck.zip")
 
 md $dst -ea silentlycontinue


### PR DESCRIPTION
Fixing installer issue when `PSModulePath` is screwed up by another installer #10. See issue comments for more details. 