### PR TITLE
Fix installation error that occurs in environments where $profile is $null

### DIFF
--- a/Install-TheFucker.ps1
+++ b/Install-TheFucker.ps1
@@ -11,7 +11,7 @@ Move-Item "$dst\PoShFuck-master\*" "$dst" -Force
 Remove-Item "$dst\PoShFuck-master" -Recurse -Force
 Remove-Item $pfk -Force
 
-if (-not(Test-Path $profile)) {
+if ($null -eq $profile -or (-not(Test-Path $profile))) {
 	Write-Output "Import-Module PoShFuck" | Out-File $profile -Force -encoding utf8
 	Write-Output "Created $profile"
 } elseif ( -not(Select-String -Path $profile -Pattern "Import-Module PoShFuck")) {


### PR DESCRIPTION
Fix installation error that occurs in environments (such as e.g. AppVeyor) where $profile is $null.

The error that one got before this PR is:
```
Test-Path : Cannot bind argument to parameter 'Path' because it is null.
At line:14 char:20
+ if (-not(Test-Path $profile)) {
+                    ~~~~~~~~
    + CategoryInfo          : InvalidData: (:) [Test-Path], ParameterBindingValidationException
    + FullyQualifiedErrorId : ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.TestPathCommand
```