### PR TITLE
Update to match new error message from powershell

### DIFF
--- a/PoShFuck.psm1
+++ b/PoShFuck.psm1
@@ -128,7 +128,7 @@ Function FuckFix {
 		return $lastcommand -replace $splitcmd, $prevmatch
 	}
 	
-	if ( $preverror -match 'is not recognized as the name of a cmdlet, function' ) {
+	if ( $preverror -match 'is not recognized as a name of a cmdlet, function' ) {
 		$icf = IsCommandFucked -Command $splitcmd
 			if ( $icf -ne $false ) { 
 				$newcommand = $newcommand -replace $splitcmd, $icf


### PR DESCRIPTION
The powershell error message has changed its wording causing this implementation to break and just return the same wrong command each time. Updated the script with the new wording to match against.