### PR TITLE
Correct Fixgit behavior via new regex matching

### DIFF
--- a/PoShFuck.psm1
+++ b/PoShFuck.psm1
@@ -359,8 +359,16 @@ Function Fixgit {
 )
 	Write-Verbose "Git command to fix: $lastcommand"
 	Invoke-Expression "$lastcommand 2>&1" -ErrorVariable gitres | Out-Null
-	$origcmd = ([string]$gitres[0]).split('')[1].Replace("'",'')
-	$correctedcmd = ([string]($gitres[1])).split('')[7]
+	if ($gitres[0] -notmatch "^git: '(\w+)'") {
+		Write-Warning "Unable to parse the original git command from the error output!"
+		return $false
+	}
+	$origcmd = $Matches[1]
+	if ($gitres[3] -notmatch "^\s+(\w+)") {
+		Write-Warning "Git either provided no suggested alternatives, or the output was in a bad format!"
+		return $false
+	}
+	$correctedcmd = $Matches[1]
 	
 	return $lastcommand -replace $origcmd,$correctedcmd
 }

--- a/PoShFuck.psm1
+++ b/PoShFuck.psm1
@@ -360,13 +360,11 @@ Function Fixgit {
 	Write-Verbose "Git command to fix: $lastcommand"
 	Invoke-Expression "$lastcommand 2>&1" -ErrorVariable gitres | Out-Null
 	if ($gitres[0] -notmatch "^git: '(\w+)'") {
-		Write-Warning "Unable to parse the original git command from the error output!"
-		return $false
+		Throw "Unable to parse the original git command from the error output!"
 	}
 	$origcmd = $Matches[1]
 	if ($gitres[3] -notmatch "^\s+(\w+)") {
-		Write-Warning "Git either provided no suggested alternatives, or the output was in a bad format!"
-		return $false
+		Throw "Git either provided no suggested alternatives, or the output was in a bad format!"
 	}
 	$correctedcmd = $Matches[1]
 	


### PR DESCRIPTION
This is the change I made locally to get the git suggestions to work for me. I had a hard time following the original logic, and can think more clearly with regex, so I switched it to use regex check the following:
1. That the first line of `$gitres` matches the expectation of `git: 'COMMAND' is ...`, matching that command to a group and assigning to `$origcmd`
2. That the fourth line of `$gitres` matches the expected pattern of whitespace followed by a subcommand name.

This assumes, however, that the git output is roughly in this format:
```
git: 'pul' is not a git command. See 'git --help'.

The most similar commands are
        pull
        push
```

Questions for maintainers before considering this pull: 
1) do you know if the above is a safe assumption? It seems reliable on my machine (running git version `2.32.0.windows.2`)... but are there widely used versions of git that have breaking differences for that output?
2) I wasn't sure what the right course of action would be if the patterns fail to match. Is throwing the right choice here? I figure if we fail to find the right suggestion, all is pretty much lost, anyway, but if there's something we can do to be more graceful, let me know!